### PR TITLE
Fix a number of issues with the datetime prompt

### DIFF
--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -343,7 +343,7 @@ impl<'a> DateTimeSelect<'a> {
                 }
                 // Increment datetime by 1.
                 Key::ArrowUp | Key::Char('j') => {
-                    date_val = match (&self.date_type, pos) {
+                    date_val = match (self.date_type, pos) {
                         (DateType::DateTime, 0) | (DateType::Date, 0) => date_val.increment_year(),
                         (DateType::DateTime, 1) | (DateType::Date, 1) => date_val.increment_month(),
                         (DateType::DateTime, 2) | (DateType::Date, 2) => {
@@ -366,7 +366,7 @@ impl<'a> DateTimeSelect<'a> {
                 }
                 // Decrement the datetime by 1.
                 Key::ArrowDown | Key::Char('k') => {
-                    date_val = match (&self.date_type, pos) {
+                    date_val = match (self.date_type, pos) {
                         (DateType::DateTime, 0) | (DateType::Date, 0) => date_val.decrement_year(),
                         (DateType::DateTime, 1) | (DateType::Date, 1) => date_val.decrement_month(),
                         (DateType::DateTime, 2) | (DateType::Date, 2) => {
@@ -489,5 +489,29 @@ mod tests {
         let mut datetime_select = DateTimeSelect::new();
         datetime_select.date_type(DateType::Date);
         assert_eq!(datetime_select.date_type, DateType::Date);
+    }
+    #[test]
+    fn test_max_min_datetimes() {
+        let mut datetime_select = DateTimeSelect::new();
+
+        datetime_select.min("2020-02-20T02:20:25Z");
+        let min_date = NaiveDate::from_ymd(2020, 2, 20).and_hms(2, 20, 25);
+        assert_eq!(datetime_select.min, min_date);
+
+        datetime_select.max("2022-11-30T00:00:00Z");
+        let max_date = NaiveDate::from_ymd(2022, 11, 30).and_hms(0, 0, 0);
+        assert_eq!(datetime_select.max, max_date);
+
+        let in_range_date = NaiveDate::from_ymd(2020, 7, 8).and_hms(17, 1, 30);
+        assert_eq!(datetime_select.check_date(in_range_date), in_range_date);
+
+        assert_eq!(
+            datetime_select.check_date(NaiveDate::from_ymd(2000, 1, 1).and_hms(0, 0, 0)),
+            min_date
+        );
+        assert_eq!(
+            datetime_select.check_date(NaiveDate::from_ymd(2030, 1, 1).and_hms(0, 0, 0)),
+            max_date
+        );
     }
 }

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -1,8 +1,6 @@
 use std::io;
 
-use chrono::{
-    DateTime, Datelike, Duration, NaiveDate, NaiveDateTime, SecondsFormat, TimeZone, Timelike, Utc,
-};
+use chrono::{DateTime, Datelike, Duration, NaiveDate, NaiveDateTime, SecondsFormat, TimeZone, Timelike, Utc};
 use console::{style, Key, Term};
 use std::cmp::{max, min};
 use theme::{get_default_theme, TermThemeRenderer, Theme};
@@ -23,26 +21,20 @@ where
     fn increment_year(&self) -> Self {
         self.with_year(self.year() + 1).unwrap_or_else(|| {
             // If we're currently on a leap day we know how to handle a failure
-            assert_eq!(self.month(), 2, "year increment failed away from leap day");
-            assert_eq!(self.day(), 29, "year increment failed away from leap day");
+            assert_eq!(self.month(), 2, "Unexpected failure in year increment. Please open a bug ticket with the current case.");
+            assert_eq!(self.day(), 29, "Unexpected failure in year increment. Please open a bug ticket with the current case.");
 
-            self.with_day(28)
-                .unwrap()
-                .with_year(self.year() + 1)
-                .unwrap()
+            self.with_day(28).unwrap().with_year(self.year() + 1).unwrap()
         })
     }
 
     fn decrement_year(&self) -> Self {
         self.with_year(self.year() - 1).unwrap_or_else(|| {
             // If we're currently on a leap day we know how to handle a failure
-            assert_eq!(self.month(), 2, "year decrement failed away from leap day");
-            assert_eq!(self.day(), 29, "year decrement failed away from leap day");
+            assert_eq!(self.month(), 2, "Unexpected failure in year decrement. Please open a bug ticket with the current case.");
+            assert_eq!(self.day(), 29, "Unexpected failure in year decrement. Please open a bug ticket with the current case.");
 
-            self.with_day(28)
-                .unwrap()
-                .with_year(self.year() - 1)
-                .unwrap()
+            self.with_day(28).unwrap().with_year(self.year() - 1).unwrap()
         })
     }
 
@@ -50,22 +42,16 @@ where
         let new_month = self.month() + 1;
         if new_month > 12 {
             // This case should be infallible since both December and January have 31 days
-            self.with_year(self.year() + 1)
-                .unwrap()
-                .with_month(1)
-                .unwrap()
+            self.with_year(self.year() + 1).unwrap().with_month(1).unwrap()
         } else {
             self.with_month(new_month).unwrap_or_else(|| {
                 // We've stepped off the end of the month most likely, adjust the day if so
                 assert!(
                     self.day() > MONTH_END_DAYS[new_month as usize],
-                    "month increment failed with valid day in next month"
+                    "Unexpected failure in month increment. Please open a bug ticket with the current case."
                 );
 
-                self.with_day(MONTH_END_DAYS[new_month as usize])
-                    .unwrap()
-                    .with_month(new_month)
-                    .unwrap()
+                self.with_day(MONTH_END_DAYS[new_month as usize]).unwrap().with_month(new_month).unwrap()
             })
         }
     }
@@ -74,22 +60,16 @@ where
         let new_month = self.month() - 1;
         if new_month < 1 {
             // This case should be infallible since both December and January have 31 days
-            self.with_year(self.year() - 1)
-                .unwrap()
-                .with_month(12)
-                .unwrap()
+            self.with_year(self.year() - 1).unwrap().with_month(12).unwrap()
         } else {
             self.with_month(new_month).unwrap_or_else(|| {
                 // We've stepped off the end of the month most likely, adjust the day if so
                 assert!(
                     self.day() > MONTH_END_DAYS[new_month as usize],
-                    "month decrement failed with valid day in next month"
+                    "Unexpected failure in month decrement. Please open a bug ticket with the current case."
                 );
 
-                self.with_day(MONTH_END_DAYS[new_month as usize])
-                    .unwrap()
-                    .with_month(new_month)
-                    .unwrap()
+                self.with_day(MONTH_END_DAYS[new_month as usize]).unwrap().with_month(new_month).unwrap()
             })
         }
     }
@@ -150,11 +130,7 @@ impl<'a> DateTimeSelect<'a> {
     }
     /// Sets default time to start with.
     pub fn default(&mut self, datetime: &str) -> &mut Self {
-        self.default = Some(
-            DateTime::parse_from_rfc3339(datetime)
-                .expect("date format must match rfc3339")
-                .naive_local(),
-        );
+        self.default = Some(DateTime::parse_from_rfc3339(datetime).expect("date format must match rfc3339").naive_local());
         self
     }
     /// Sets whether to show weekday or not.
@@ -169,17 +145,13 @@ impl<'a> DateTimeSelect<'a> {
     }
     /// Sets min value for Date or DateTime.
     pub fn min(&mut self, val: &str) -> &mut Self {
-        self.min = DateTime::parse_from_rfc3339(val)
-            .expect("date format must match rfc3339")
-            .naive_local();
+        self.min = DateTime::parse_from_rfc3339(val).expect("date format must match rfc3339").naive_local();
         assert!(self.max >= self.min, "maximum must be larger than minimum");
         self
     }
     /// Sets max value for Date or DateTime.
     pub fn max(&mut self, val: &'a str) -> &mut Self {
-        self.max = DateTime::parse_from_rfc3339(val)
-            .expect("date format must match rfc3339")
-            .naive_local();
+        self.max = DateTime::parse_from_rfc3339(val).expect("date format must match rfc3339").naive_local();
         assert!(self.max >= self.min, "maximum must be larger than minimum");
         self
     }
@@ -202,72 +174,24 @@ impl<'a> DateTimeSelect<'a> {
         match self.date_type {
             DateType::Date => format!(
                 "{}-{:02}-{:02}",
-                if pos == 0 {
-                    style(val.year()).bold()
-                } else {
-                    style(val.year()).dim()
-                },
-                if pos == 1 {
-                    style(val.month()).bold()
-                } else {
-                    style(val.month()).dim()
-                },
-                if pos == 2 {
-                    style(val.day()).bold()
-                } else {
-                    style(val.day()).dim()
-                },
+                if pos == 0 { style(val.year()).bold() } else { style(val.year()).dim() },
+                if pos == 1 { style(val.month()).bold() } else { style(val.month()).dim() },
+                if pos == 2 { style(val.day()).bold() } else { style(val.day()).dim() },
             ),
             DateType::Time => format!(
                 "{:02}:{:02}:{:02}",
-                if pos == 0 {
-                    style(val.hour()).bold()
-                } else {
-                    style(val.hour()).dim()
-                },
-                if pos == 1 {
-                    style(val.minute()).bold()
-                } else {
-                    style(val.minute()).dim()
-                },
-                if pos == 2 {
-                    style(val.second()).bold()
-                } else {
-                    style(val.second()).dim()
-                },
+                if pos == 0 { style(val.hour()).bold() } else { style(val.hour()).dim() },
+                if pos == 1 { style(val.minute()).bold() } else { style(val.minute()).dim() },
+                if pos == 2 { style(val.second()).bold() } else { style(val.second()).dim() },
             ),
             DateType::DateTime => format!(
                 "{}-{:02}-{:02} {:02}:{:02}:{:02}",
-                if pos == 0 {
-                    style(val.year()).bold()
-                } else {
-                    style(val.year()).dim()
-                },
-                if pos == 1 {
-                    style(val.month()).bold()
-                } else {
-                    style(val.month()).dim()
-                },
-                if pos == 2 {
-                    style(val.day()).bold()
-                } else {
-                    style(val.day()).dim()
-                },
-                if pos == 3 {
-                    style(val.hour()).bold()
-                } else {
-                    style(val.hour()).dim()
-                },
-                if pos == 4 {
-                    style(val.minute()).bold()
-                } else {
-                    style(val.minute()).dim()
-                },
-                if pos == 5 {
-                    style(val.second()).bold()
-                } else {
-                    style(val.second()).dim()
-                },
+                if pos == 0 { style(val.year()).bold() } else { style(val.year()).dim() },
+                if pos == 1 { style(val.month()).bold() } else { style(val.month()).dim() },
+                if pos == 2 { style(val.day()).bold() } else { style(val.day()).dim() },
+                if pos == 3 { style(val.hour()).bold() } else { style(val.hour()).dim() },
+                if pos == 4 { style(val.minute()).bold() } else { style(val.minute()).dim() },
+                if pos == 5 { style(val.second()).bold() } else { style(val.second()).dim() },
             ),
         }
     }
@@ -290,7 +214,7 @@ impl<'a> DateTimeSelect<'a> {
 
         // Set vars for handling changing datetimes.
         let mut pos = 0;
-        let max_pos = match &self.date_type {
+        let max_pos = match self.date_type {
             DateType::Date => 2,
             DateType::Time => 2,
             DateType::DateTime => 5,
@@ -329,9 +253,7 @@ impl<'a> DateTimeSelect<'a> {
                     let date_str = match self.date_type {
                         DateType::Date => date_val.format("%Y-%m-%d").to_string(),
                         DateType::Time => date_val.format("%H:%M:%S").to_string(),
-                        DateType::DateTime => Utc
-                            .from_utc_datetime(&date_val)
-                            .to_rfc3339_opts(SecondsFormat::Secs, true),
+                        DateType::DateTime => Utc.from_utc_datetime(&date_val).to_rfc3339_opts(SecondsFormat::Secs, true),
                     };
                     return Ok(date_str);
                 }
@@ -348,18 +270,10 @@ impl<'a> DateTimeSelect<'a> {
                     date_val = match (self.date_type, pos) {
                         (DateType::DateTime, 0) | (DateType::Date, 0) => date_val.increment_year(),
                         (DateType::DateTime, 1) | (DateType::Date, 1) => date_val.increment_month(),
-                        (DateType::DateTime, 2) | (DateType::Date, 2) => {
-                            date_val + Duration::days(1)
-                        }
-                        (DateType::DateTime, 3) | (DateType::Time, 0) => {
-                            date_val + Duration::hours(1)
-                        }
-                        (DateType::DateTime, 4) | (DateType::Time, 1) => {
-                            date_val + Duration::minutes(1)
-                        }
-                        (DateType::DateTime, 5) | (DateType::Time, 2) => {
-                            date_val + Duration::seconds(1)
-                        }
+                        (DateType::DateTime, 2) | (DateType::Date, 2) => date_val + Duration::days(1),
+                        (DateType::DateTime, 3) | (DateType::Time, 0) => date_val + Duration::hours(1),
+                        (DateType::DateTime, 4) | (DateType::Time, 1) => date_val + Duration::minutes(1),
+                        (DateType::DateTime, 5) | (DateType::Time, 2) => date_val + Duration::seconds(1),
                         (DateType::Date, _) => panic!("stepped out of bounds on Date"),
                         (DateType::Time, _) => panic!("stepped out of bounds on Time"),
                         (DateType::DateTime, _) => panic!("stepped out of bounds on DateTime"),
@@ -371,18 +285,10 @@ impl<'a> DateTimeSelect<'a> {
                     date_val = match (self.date_type, pos) {
                         (DateType::DateTime, 0) | (DateType::Date, 0) => date_val.decrement_year(),
                         (DateType::DateTime, 1) | (DateType::Date, 1) => date_val.decrement_month(),
-                        (DateType::DateTime, 2) | (DateType::Date, 2) => {
-                            date_val - Duration::days(1)
-                        }
-                        (DateType::DateTime, 3) | (DateType::Time, 0) => {
-                            date_val - Duration::hours(1)
-                        }
-                        (DateType::DateTime, 4) | (DateType::Time, 1) => {
-                            date_val - Duration::minutes(1)
-                        }
-                        (DateType::DateTime, 5) | (DateType::Time, 2) => {
-                            date_val - Duration::seconds(1)
-                        }
+                        (DateType::DateTime, 2) | (DateType::Date, 2) => date_val - Duration::days(1),
+                        (DateType::DateTime, 3) | (DateType::Time, 0) => date_val - Duration::hours(1),
+                        (DateType::DateTime, 4) | (DateType::Time, 1) => date_val - Duration::minutes(1),
+                        (DateType::DateTime, 5) | (DateType::Time, 2) => date_val - Duration::seconds(1),
                         (DateType::Date, _) => panic!("stepped out of bounds on Date"),
                         (DateType::Time, _) => panic!("stepped out of bounds on Time"),
                         (DateType::DateTime, _) => panic!("stepped out of bounds on DateTime"),
@@ -395,43 +301,27 @@ impl<'a> DateTimeSelect<'a> {
                         digits.push(digit);
                         // Need 4 digits to set year
                         if pos == 0 && digits.len() == 4 {
-                            let num =
-                                digits[0] * 1000 + digits[1] * 100 + digits[2] * 10 + digits[3];
+                            let num = digits[0] * 1000 + digits[1] * 100 + digits[2] * 10 + digits[3];
 
                             date_val = match self.date_type {
-                                DateType::Date | DateType::DateTime => {
-                                    date_val.with_year(num as i32)
-                                }
+                                DateType::Date | DateType::DateTime => date_val.with_year(num as i32),
                                 DateType::Time => panic!("Time not supported for 4 digits"),
                             }
                             .unwrap_or(date_val);
 
                             digits.clear();
                         // Have 2 digits in any position, including 0 if hours.
-                        } else if digits.len() == 2 && (pos > 0 || self.date_type == DateType::Time)
-                        {
+                        } else if digits.len() == 2 && (pos > 0 || self.date_type == DateType::Time) {
                             let num = digits[0] * 10 + digits[1];
                             date_val = match (self.date_type, pos) {
-                                (DateType::DateTime, 1) | (DateType::Date, 1) => {
-                                    date_val.with_month(num)
-                                }
-                                (DateType::DateTime, 2) | (DateType::Date, 2) => {
-                                    date_val.with_day(num)
-                                }
-                                (DateType::DateTime, 3) | (DateType::Time, 0) => {
-                                    date_val.with_hour(num)
-                                }
-                                (DateType::DateTime, 4) | (DateType::Time, 1) => {
-                                    date_val.with_minute(num)
-                                }
-                                (DateType::DateTime, 5) | (DateType::Time, 2) => {
-                                    date_val.with_second(num)
-                                }
+                                (DateType::DateTime, 1) | (DateType::Date, 1) => date_val.with_month(num),
+                                (DateType::DateTime, 2) | (DateType::Date, 2) => date_val.with_day(num),
+                                (DateType::DateTime, 3) | (DateType::Time, 0) => date_val.with_hour(num),
+                                (DateType::DateTime, 4) | (DateType::Time, 1) => date_val.with_minute(num),
+                                (DateType::DateTime, 5) | (DateType::Time, 2) => date_val.with_second(num),
                                 (DateType::Date, _) => panic!("stepped out of bounds on Date"),
                                 (DateType::Time, _) => panic!("stepped out of bounds on Time"),
-                                (DateType::DateTime, _) => {
-                                    panic!("stepped out of bounds on DateTime")
-                                }
+                                (DateType::DateTime, _) => panic!("stepped out of bounds on DateTime"),
                             }
                             .unwrap_or(date_val);
                             digits.clear();
@@ -469,10 +359,7 @@ mod tests {
     fn test_setting_proper_rfc3339_default() {
         let mut datetime_select = DateTimeSelect::new();
         datetime_select.default("2019-01-01T00:00:00-00:00");
-        assert_eq!(
-            datetime_select.default,
-            Some(NaiveDate::from_ymd(2019, 1, 1).and_hms_milli(0, 0, 0, 0))
-        );
+        assert_eq!(datetime_select.default, Some(NaiveDate::from_ymd(2019, 1, 1).and_hms_milli(0, 0, 0, 0)));
     }
     #[test]
     fn test_setting_prompt() {
@@ -507,13 +394,7 @@ mod tests {
         let in_range_date = NaiveDate::from_ymd(2020, 7, 8).and_hms(17, 1, 30);
         assert_eq!(datetime_select.check_date(in_range_date), in_range_date);
 
-        assert_eq!(
-            datetime_select.check_date(NaiveDate::from_ymd(2000, 1, 1).and_hms(0, 0, 0)),
-            min_date
-        );
-        assert_eq!(
-            datetime_select.check_date(NaiveDate::from_ymd(2030, 1, 1).and_hms(0, 0, 0)),
-            max_date
-        );
+        assert_eq!(datetime_select.check_date(NaiveDate::from_ymd(2000, 1, 1).and_hms(0, 0, 0)), min_date);
+        assert_eq!(datetime_select.check_date(NaiveDate::from_ymd(2030, 1, 1).and_hms(0, 0, 0)), max_date);
     }
 }

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -365,70 +365,42 @@ impl<'a> DateTimeSelect<'a> {
                 // Increment datetime by 1.
                 Key::ArrowUp | Key::Char('j') => {
                     date_val = match (&self.date_type, pos) {
-                        (DateType::Date, 0) => date_val.increment_year(),
-                        (DateType::Date, 1) => date_val.increment_month(),
-                        (DateType::Date, 2) => {
-                            date_val.checked_add_signed(Duration::days(1)).unwrap()
+                        (DateType::DateTime, 0) | (DateType::Date, 0) => date_val.increment_year(),
+                        (DateType::DateTime, 1) | (DateType::Date, 1) => date_val.increment_month(),
+                        (DateType::DateTime, 2) | (DateType::Date, 2) => {
+                            date_val + Duration::days(1)
                         }
-                        (DateType::Time, 0) => {
-                            date_val.checked_add_signed(Duration::hours(1)).unwrap()
+                        (DateType::DateTime, 3) | (DateType::Time, 0) => {
+                            date_val + Duration::hours(1)
                         }
-                        (DateType::Time, 1) => {
-                            date_val.checked_add_signed(Duration::minutes(1)).unwrap()
+                        (DateType::DateTime, 4) | (DateType::Time, 1) => {
+                            date_val + Duration::minutes(1)
                         }
-                        (DateType::Time, 2) => {
-                            date_val.checked_add_signed(Duration::seconds(1)).unwrap()
-                        }
-                        (DateType::DateTime, 0) => date_val.increment_year(),
-                        (DateType::DateTime, 1) => date_val.increment_month(),
-                        (DateType::DateTime, 2) => {
-                            date_val.checked_add_signed(Duration::days(1)).unwrap()
-                        }
-                        (DateType::DateTime, 3) => {
-                            date_val.checked_add_signed(Duration::hours(1)).unwrap()
-                        }
-                        (DateType::DateTime, 4) => {
-                            date_val.checked_add_signed(Duration::minutes(1)).unwrap()
-                        }
-                        (DateType::DateTime, 5) => {
-                            date_val.checked_add_signed(Duration::seconds(1)).unwrap()
+                        (DateType::DateTime, 5) | (DateType::Time, 2) => {
+                            date_val + Duration::seconds(1)
                         }
                         (DateType::Date, _) => panic!("stepped out of bounds on Date"),
                         (DateType::Time, _) => panic!("stepped out of bounds on Time"),
                         (DateType::DateTime, _) => panic!("stepped out of bounds on DateTime"),
                     };
-                    digits = Vec::with_capacity(4);
+                    digits.clear();
                 }
                 // Decrement the datetime by 1.
                 Key::ArrowDown | Key::Char('k') => {
                     date_val = match (&self.date_type, pos) {
-                        (DateType::Date, 0) => date_val.decrement_year(),
-                        (DateType::Date, 1) => date_val.decrement_month(),
-                        (DateType::Date, 2) => {
-                            date_val.checked_sub_signed(Duration::days(1)).unwrap()
+                        (DateType::DateTime, 0) | (DateType::Date, 0) => date_val.decrement_year(),
+                        (DateType::DateTime, 1) | (DateType::Date, 1) => date_val.decrement_month(),
+                        (DateType::DateTime, 2) | (DateType::Date, 2) => {
+                            date_val - Duration::days(1)
                         }
-                        (DateType::Time, 0) => {
-                            date_val.checked_sub_signed(Duration::hours(1)).unwrap()
+                        (DateType::DateTime, 3) | (DateType::Time, 0) => {
+                            date_val - Duration::hours(1)
                         }
-                        (DateType::Time, 1) => {
-                            date_val.checked_sub_signed(Duration::minutes(1)).unwrap()
+                        (DateType::DateTime, 4) | (DateType::Time, 1) => {
+                            date_val - Duration::minutes(1)
                         }
-                        (DateType::Time, 2) => {
-                            date_val.checked_sub_signed(Duration::seconds(1)).unwrap()
-                        }
-                        (DateType::DateTime, 0) => date_val.decrement_year(),
-                        (DateType::DateTime, 1) => date_val.decrement_month(),
-                        (DateType::DateTime, 2) => {
-                            date_val.checked_sub_signed(Duration::days(1)).unwrap()
-                        }
-                        (DateType::DateTime, 3) => {
-                            date_val.checked_sub_signed(Duration::hours(1)).unwrap()
-                        }
-                        (DateType::DateTime, 4) => {
-                            date_val.checked_sub_signed(Duration::minutes(1)).unwrap()
-                        }
-                        (DateType::DateTime, 5) => {
-                            date_val.checked_sub_signed(Duration::seconds(1)).unwrap()
+                        (DateType::DateTime, 5) | (DateType::Time, 2) => {
+                            date_val - Duration::seconds(1)
                         }
                         (DateType::Date, _) => panic!("stepped out of bounds on Date"),
                         (DateType::Time, _) => panic!("stepped out of bounds on Time"),

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -416,47 +416,43 @@ impl<'a> DateTimeSelect<'a> {
                         if pos == 0 && digits.len() == 4 {
                             let num =
                                 digits[0] * 1000 + digits[1] * 100 + digits[2] * 10 + digits[3];
-                            date_val = match &self.date_type {
-                                DateType::Date => date_val.with_year(num as i32).unwrap(),
-                                DateType::DateTime => date_val.with_year(num as i32).unwrap(),
+
+                            date_val = match self.date_type {
+                                DateType::Date | DateType::DateTime => {
+                                    date_val.with_year(num as i32)
+                                }
                                 DateType::Time => panic!("Time not supported for 4 digits"),
-                            };
+                            }
+                            .unwrap_or(date_val);
+
                             digits.clear();
                         // Have 2 digits in any position, including 0 if hours.
                         } else if digits.len() == 2 && (pos > 0 || self.date_type == DateType::Time)
                         {
                             let num = digits[0] * 10 + digits[1];
-                            date_val = match (&self.date_type, pos) {
-                                (DateType::Date, 1) => date_val.with_month(num).unwrap_or(date_val),
-                                (DateType::Date, 2) => date_val.with_day(num).unwrap_or(date_val),
-                                (DateType::Time, 0) => date_val.with_hour(num).unwrap_or(date_val),
-                                (DateType::Time, 1) => {
-                                    date_val.with_minute(num).unwrap_or(date_val)
+                            date_val = match (self.date_type, pos) {
+                                (DateType::DateTime, 1) | (DateType::Date, 1) => {
+                                    date_val.with_month(num)
                                 }
-                                (DateType::Time, 2) => {
-                                    date_val.with_second(num).unwrap_or(date_val)
+                                (DateType::DateTime, 2) | (DateType::Date, 2) => {
+                                    date_val.with_day(num)
                                 }
-                                (DateType::DateTime, 1) => {
-                                    date_val.with_month(num).unwrap_or(date_val)
+                                (DateType::DateTime, 3) | (DateType::Time, 0) => {
+                                    date_val.with_hour(num)
                                 }
-                                (DateType::DateTime, 2) => {
-                                    date_val.with_day(num).unwrap_or(date_val)
+                                (DateType::DateTime, 4) | (DateType::Time, 1) => {
+                                    date_val.with_minute(num)
                                 }
-                                (DateType::DateTime, 3) => {
-                                    date_val.with_hour(num).unwrap_or(date_val)
-                                }
-                                (DateType::DateTime, 4) => {
-                                    date_val.with_minute(num).unwrap_or(date_val)
-                                }
-                                (DateType::DateTime, 5) => {
-                                    date_val.with_second(num).unwrap_or(date_val)
+                                (DateType::DateTime, 5) | (DateType::Time, 2) => {
+                                    date_val.with_second(num)
                                 }
                                 (DateType::Date, _) => panic!("stepped out of bounds on Date"),
                                 (DateType::Time, _) => panic!("stepped out of bounds on Time"),
                                 (DateType::DateTime, _) => {
                                     panic!("stepped out of bounds on DateTime")
                                 }
-                            };
+                            }
+                            .unwrap_or(date_val);
                             digits.clear();
                         }
                     } else {

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -172,6 +172,7 @@ impl<'a> DateTimeSelect<'a> {
         self.min = DateTime::parse_from_rfc3339(val)
             .expect("date format must match rfc3339")
             .naive_local();
+        assert!(self.max >= self.min, "maximum must be larger than minimum");
         self
     }
     /// Sets max value for Date or DateTime.
@@ -179,6 +180,7 @@ impl<'a> DateTimeSelect<'a> {
         self.max = DateTime::parse_from_rfc3339(val)
             .expect("date format must match rfc3339")
             .naive_local();
+        assert!(self.max >= self.min, "maximum must be larger than minimum");
         self
     }
     /// Sets whether to clear inputs from terminal.

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -1,8 +1,9 @@
 use std::io;
 
+use chrono::{DateTime, Datelike, Duration, FixedOffset, TimeZone, Timelike, Utc};
+use console::{style, Key, Term};
+use std::cmp::{max, min};
 use theme::{get_default_theme, TermThemeRenderer, Theme};
-use chrono::{DateTime, Duration, Datelike, FixedOffset, Timelike, Utc};
-use console::{Key, Term, style};
 
 /// The possible types of datetime selections that can be made.
 #[derive(Clone, Debug, PartialEq)]
@@ -23,17 +24,17 @@ pub enum DateType {
 /// Note: Date values can be changed by UP/DOWN/j/k or specifying numerical values.
 pub struct DateTimeSelect<'a> {
     prompt: Option<String>,
-    default: Option<String>,
+    default: Option<DateTime<FixedOffset>>,
     theme: &'a dyn Theme,
     weekday: bool,
     date_type: DateType,
-    min: &'a str,
-    max: &'a str,
+    min: DateTime<FixedOffset>,
+    max: DateTime<FixedOffset>,
     clear: bool,
     show_match: bool,
 }
 
-impl <'a> DateTimeSelect<'a> {
+impl<'a> DateTimeSelect<'a> {
     pub fn new() -> DateTimeSelect<'static> {
         DateTimeSelect::with_theme(get_default_theme())
     }
@@ -46,61 +47,55 @@ impl <'a> DateTimeSelect<'a> {
             theme,
             weekday: true,
             date_type: DateType::DateTime,
-            min: "0000-01-01T00:00:00-00:00",
-            max: "9999-12-31T23:59:59-00:00",
+            min: FixedOffset::east(0).ymd(0, 1, 1).and_hms(0, 0, 0),
+            max: FixedOffset::east(0).ymd(9999, 12, 31).and_hms(23, 59, 59),
             clear: true,
             show_match: false,
         }
     }
     /// Sets the datetime prompt.
-    pub fn with_prompt(&mut self, prompt: &str) -> &mut DateTimeSelect<'a> {
+    pub fn with_prompt(&mut self, prompt: &str) -> &mut Self {
         self.prompt = Some(prompt.into());
         self
     }
     /// Sets default time to start with.
-    pub fn default(&mut self, datetime: &str) -> &mut DateTimeSelect<'a> {
-        self.default = Some(datetime.into());
+    pub fn default(&mut self, datetime: &str) -> &mut Self {
+        self.default =
+            Some(DateTime::parse_from_rfc3339(datetime).expect("date format must match rfc3339"));
         self
     }
     /// Sets whether to show weekday or not.
-    pub fn weekday(&mut self, val: bool) -> &mut DateTimeSelect<'a> {
+    pub fn weekday(&mut self, val: bool) -> &mut Self {
         self.weekday = val;
         self
     }
     /// Sets date selector to date, time, or datetime format.
-    pub fn date_type(&mut self, val: DateType) -> &mut DateTimeSelect<'a> {
-        self.date_type = val; 
+    pub fn date_type(&mut self, val: DateType) -> &mut Self {
+        self.date_type = val;
         self
     }
     /// Sets min value for Date or DateTime.
-    pub fn min(&mut self, val: &'a str) -> &mut DateTimeSelect<'a> {
-        self.min = val;
+    pub fn min(&mut self, val: &str) -> &mut Self {
+        self.min = DateTime::parse_from_rfc3339(val).expect("date format must match rfc3339");
         self
     }
     /// Sets max value for Date or DateTime.
-    pub fn max(&mut self, val: &'a str) -> &mut DateTimeSelect<'a> {
-        self.max = val;
+    pub fn max(&mut self, val: &'a str) -> &mut Self {
+        self.max = DateTime::parse_from_rfc3339(val).expect("date format must match rfc3339");
         self
     }
     /// Sets whether to clear inputs from terminal.
-    pub fn clear(&mut self, val: bool) -> &mut DateTimeSelect<'a> {
+    pub fn clear(&mut self, val: bool) -> &mut Self {
         self.clear = val;
         self
     }
     /// Sets whether to show match string or not.
-    pub fn show_match(&mut self, val: bool) -> &mut DateTimeSelect<'a> {
+    pub fn show_match(&mut self, val: bool) -> &mut Self {
         self.show_match = val;
         self
     }
-    fn check_date(&self, val: DateTime<FixedOffset>, min: &DateTime<FixedOffset>, max: &DateTime<FixedOffset>) -> DateTime<FixedOffset> {
-        let val = if val < *min {
-            min.clone()
-        } else if val > *max {
-            max.clone()
-        } else {
-            val
-        };
-        val
+    fn check_date(&self, val: DateTime<FixedOffset>) -> DateTime<FixedOffset> {
+        min(max(val, self.min), self.max)
     }
     /// Enables user interaction and returns the result.
     ///
@@ -111,7 +106,7 @@ impl <'a> DateTimeSelect<'a> {
     /// Like `interact` but allows a specific terminal to be set.
     fn interact_on(&self, term: &Term) -> io::Result<String> {
         // Current date in UTC is used as default time if override not set.
-        let now = Utc::now() 
+        let now = Utc::now()
             .with_hour(0)
             .unwrap()
             .with_minute(0)
@@ -119,18 +114,11 @@ impl <'a> DateTimeSelect<'a> {
             .with_second(0)
             .unwrap();
 
-        let min_val = DateTime::parse_from_rfc3339(self.min).expect("date format must match rfc3339");
-        let max_val = DateTime::parse_from_rfc3339(self.max).expect("date format must match rfc3339");
+        let mut date_val = self.default.unwrap_or_else(|| {
+            DateTime::parse_from_rfc3339(&now.to_rfc3339()).expect("date format must match rfc3339")
+        });
 
-        let mut date_val = match &self.default {
-            Some(datetime) => {
-                DateTime::parse_from_rfc3339(datetime).expect("date format must match rfc3339")
-            },
-            None => {
-                DateTime::parse_from_rfc3339(&now.to_rfc3339()).expect("date format must match rfc3339")
-            }
-        };
-        date_val = self.check_date(date_val, &min_val, &max_val);
+        date_val = self.check_date(date_val);
         let mut render = TermThemeRenderer::new(term, self.theme);
 
         // Set vars for handling changing datetimes.
@@ -145,33 +133,75 @@ impl <'a> DateTimeSelect<'a> {
         loop {
             // Styling is added to highlight pos being changed.
             let date_str = match &self.date_type {
-                DateType::Date => {
-                    format!(
-                        "{}-{:02}-{:02}",
-                        if pos == 0 { style(date_val.year()).bold() } else { style(date_val.year()).dim() },
-                        if pos == 1 { style(date_val.month()).bold() } else { style(date_val.month()).dim() },
-                        if pos == 2 { style(date_val.day()).bold() } else { style(date_val.day()).dim() },
-                    )
-                },
-                DateType::Time => {
-                    format!(
-                        "{:02}:{:02}:{:02}",
-                        if pos == 0 { style(date_val.hour()).bold() } else { style(date_val.hour()).dim() },
-                        if pos == 1 { style(date_val.minute()).bold() } else { style(date_val.minute()).dim() },
-                        if pos == 2 { style(date_val.second()).bold() } else { style(date_val.second()).dim() },
-                    )
-                },
-                DateType::DateTime => {
-                    format!(
-                        "{}-{:02}-{:02} {:02}:{:02}:{:02}",
-                        if pos == 0 { style(date_val.year()).bold() } else { style(date_val.year()).dim() },
-                        if pos == 1 { style(date_val.month()).bold() } else { style(date_val.month()).dim() },
-                        if pos == 2 { style(date_val.day()).bold() } else { style(date_val.day()).dim() },
-                        if pos == 3 { style(date_val.hour()).bold() } else { style(date_val.hour()).dim() },
-                        if pos == 4 { style(date_val.minute()).bold() } else { style(date_val.minute()).dim() },
-                        if pos == 5 { style(date_val.second()).bold() } else { style(date_val.second()).dim() },
-                    )
-                },
+                DateType::Date => format!(
+                    "{}-{:02}-{:02}",
+                    if pos == 0 {
+                        style(date_val.year()).bold()
+                    } else {
+                        style(date_val.year()).dim()
+                    },
+                    if pos == 1 {
+                        style(date_val.month()).bold()
+                    } else {
+                        style(date_val.month()).dim()
+                    },
+                    if pos == 2 {
+                        style(date_val.day()).bold()
+                    } else {
+                        style(date_val.day()).dim()
+                    },
+                ),
+                DateType::Time => format!(
+                    "{:02}:{:02}:{:02}",
+                    if pos == 0 {
+                        style(date_val.hour()).bold()
+                    } else {
+                        style(date_val.hour()).dim()
+                    },
+                    if pos == 1 {
+                        style(date_val.minute()).bold()
+                    } else {
+                        style(date_val.minute()).dim()
+                    },
+                    if pos == 2 {
+                        style(date_val.second()).bold()
+                    } else {
+                        style(date_val.second()).dim()
+                    },
+                ),
+                DateType::DateTime => format!(
+                    "{}-{:02}-{:02} {:02}:{:02}:{:02}",
+                    if pos == 0 {
+                        style(date_val.year()).bold()
+                    } else {
+                        style(date_val.year()).dim()
+                    },
+                    if pos == 1 {
+                        style(date_val.month()).bold()
+                    } else {
+                        style(date_val.month()).dim()
+                    },
+                    if pos == 2 {
+                        style(date_val.day()).bold()
+                    } else {
+                        style(date_val.day()).dim()
+                    },
+                    if pos == 3 {
+                        style(date_val.hour()).bold()
+                    } else {
+                        style(date_val.hour()).dim()
+                    },
+                    if pos == 4 {
+                        style(date_val.minute()).bold()
+                    } else {
+                        style(date_val.minute()).dim()
+                    },
+                    if pos == 5 {
+                        style(date_val.second()).bold()
+                    } else {
+                        style(date_val.second()).dim()
+                    },
+                ),
             };
 
             // Add weekday if specified.
@@ -185,11 +215,7 @@ impl <'a> DateTimeSelect<'a> {
 
             // Display typed numbers if show_match is true.
             if self.show_match {
-                let str_num: Vec<String> = digits
-                    .iter()
-                    .cloned()
-                    .map(|c| c.to_string())
-                    .collect();
+                let str_num: Vec<String> = digits.iter().cloned().map(|c| c.to_string()).collect();
                 let str_num: String = str_num.join("");
                 term.write_line(&str_num[..])?;
             }
@@ -205,125 +231,160 @@ impl <'a> DateTimeSelect<'a> {
                     }
                     // Clean up formatting of returned string.
                     let date_str = match &self.date_type {
-                        DateType::Date => {
-                            format!(
-                                "{}-{:02}-{:02}",
-                                date_val.year(),
-                                date_val.month(),
-                                date_val.day(),
-                            )
-                        },
-                        DateType::Time => {
-                            format!(
-                                "{:02}:{:02}:{:02}",
-                                date_val.hour(),
-                                date_val.minute(),
-                                date_val.second(),
-                            )
-                        },
-                        DateType::DateTime => {
-                            format!(
-                                "{}-{:02}-{:02} {:02}:{:02}:{:02}",
-                                date_val.year(),
-                                date_val.month(),
-                                date_val.day(),
-                                date_val.hour(),
-                                date_val.minute(),
-                                date_val.second(),
-                            )
-                        },
+                        DateType::Date => format!(
+                            "{}-{:02}-{:02}",
+                            date_val.year(),
+                            date_val.month(),
+                            date_val.day(),
+                        ),
+                        DateType::Time => format!(
+                            "{:02}:{:02}:{:02}",
+                            date_val.hour(),
+                            date_val.minute(),
+                            date_val.second(),
+                        ),
+                        DateType::DateTime => format!(
+                            "{}-{:02}-{:02} {:02}:{:02}:{:02}",
+                            date_val.year(),
+                            date_val.month(),
+                            date_val.day(),
+                            date_val.hour(),
+                            date_val.minute(),
+                            date_val.second(),
+                        ),
                     };
                     return Ok(date_str.to_owned());
-                },
+                }
                 Key::ArrowRight | Key::Char('l') => {
-                    pos = if pos == max_pos {
-                        0
-                    } else {
-                        pos + 1
-                    };
+                    pos = if pos == max_pos { 0 } else { pos + 1 };
                     digits = Vec::with_capacity(4);
-                },
+                }
                 Key::ArrowLeft | Key::Char('h') => {
-                    pos = if pos == 0 {
-                        max_pos
-                    } else {
-                        pos - 1
-                    };
+                    pos = if pos == 0 { max_pos } else { pos - 1 };
                     digits = Vec::with_capacity(4);
-                },
+                }
                 // Increment datetime by 1.
                 Key::ArrowUp | Key::Char('j') => {
                     date_val = match (&self.date_type, pos) {
                         (DateType::Date, 0) => date_val.with_year(date_val.year() + 1).unwrap(),
                         (DateType::Date, 1) => {
                             if date_val.month() + 1 > 12 {
-                                date_val.with_year(date_val.year() + 1).unwrap().with_month(1).unwrap()
+                                date_val
+                                    .with_year(date_val.year() + 1)
+                                    .unwrap()
+                                    .with_month(1)
+                                    .unwrap()
                             } else {
                                 date_val.with_month(date_val.month() + 1).unwrap()
                             }
                         }
-                        (DateType::Date, 2) => date_val.checked_add_signed(Duration::days(1)).unwrap(),
-                        (DateType::Time, 0) => date_val.checked_add_signed(Duration::hours(1)).unwrap(),
-                        (DateType::Time, 1) => date_val.checked_add_signed(Duration::minutes(1)).unwrap(),
-                        (DateType::Time, 2) => date_val.checked_add_signed(Duration::seconds(1)).unwrap(),
+                        (DateType::Date, 2) => {
+                            date_val.checked_add_signed(Duration::days(1)).unwrap()
+                        }
+                        (DateType::Time, 0) => {
+                            date_val.checked_add_signed(Duration::hours(1)).unwrap()
+                        }
+                        (DateType::Time, 1) => {
+                            date_val.checked_add_signed(Duration::minutes(1)).unwrap()
+                        }
+                        (DateType::Time, 2) => {
+                            date_val.checked_add_signed(Duration::seconds(1)).unwrap()
+                        }
                         (DateType::DateTime, 0) => date_val.with_year(date_val.year() + 1).unwrap(),
                         (DateType::DateTime, 1) => {
                             if date_val.month() + 1 > 12 {
-                                date_val.with_year(date_val.year() + 1).unwrap().with_month(1).unwrap()
+                                date_val
+                                    .with_year(date_val.year() + 1)
+                                    .unwrap()
+                                    .with_month(1)
+                                    .unwrap()
                             } else {
                                 date_val.with_month(date_val.month() + 1).unwrap()
                             }
                         }
-                        (DateType::DateTime, 2) => date_val.checked_add_signed(Duration::days(1)).unwrap(),
-                        (DateType::DateTime, 3) => date_val.checked_add_signed(Duration::hours(1)).unwrap(),
-                        (DateType::DateTime, 4) => date_val.checked_add_signed(Duration::minutes(1)).unwrap(),
-                        (DateType::DateTime, 5) => date_val.checked_add_signed(Duration::seconds(1)).unwrap(),
+                        (DateType::DateTime, 2) => {
+                            date_val.checked_add_signed(Duration::days(1)).unwrap()
+                        }
+                        (DateType::DateTime, 3) => {
+                            date_val.checked_add_signed(Duration::hours(1)).unwrap()
+                        }
+                        (DateType::DateTime, 4) => {
+                            date_val.checked_add_signed(Duration::minutes(1)).unwrap()
+                        }
+                        (DateType::DateTime, 5) => {
+                            date_val.checked_add_signed(Duration::seconds(1)).unwrap()
+                        }
                         (DateType::Date, _) => panic!("stepped out of bounds on Date"),
                         (DateType::Time, _) => panic!("stepped out of bounds on Time"),
                         (DateType::DateTime, _) => panic!("stepped out of bounds on DateTime"),
                     };
                     digits = Vec::with_capacity(4);
-                },
+                }
                 // Decrement the datetime by 1.
                 Key::ArrowDown | Key::Char('k') => {
                     date_val = match (&self.date_type, pos) {
                         (DateType::Date, 0) => date_val.with_year(date_val.year() - 1).unwrap(),
                         (DateType::Date, 1) => {
                             if date_val.month() - 1 == 0 {
-                                date_val.with_year(date_val.year() - 1).unwrap().with_month(12).unwrap()
+                                date_val
+                                    .with_year(date_val.year() - 1)
+                                    .unwrap()
+                                    .with_month(12)
+                                    .unwrap()
                             } else {
                                 date_val.with_month(date_val.month() - 1).unwrap()
                             }
                         }
-                        (DateType::Date, 2) => date_val.checked_sub_signed(Duration::days(1)).unwrap(),
-                        (DateType::Time, 0) => date_val.checked_sub_signed(Duration::hours(1)).unwrap(),
-                        (DateType::Time, 1) => date_val.checked_sub_signed(Duration::minutes(1)).unwrap(),
-                        (DateType::Time, 2) => date_val.checked_sub_signed(Duration::seconds(1)).unwrap(),
+                        (DateType::Date, 2) => {
+                            date_val.checked_sub_signed(Duration::days(1)).unwrap()
+                        }
+                        (DateType::Time, 0) => {
+                            date_val.checked_sub_signed(Duration::hours(1)).unwrap()
+                        }
+                        (DateType::Time, 1) => {
+                            date_val.checked_sub_signed(Duration::minutes(1)).unwrap()
+                        }
+                        (DateType::Time, 2) => {
+                            date_val.checked_sub_signed(Duration::seconds(1)).unwrap()
+                        }
                         (DateType::DateTime, 0) => date_val.with_year(date_val.year() - 1).unwrap(),
                         (DateType::DateTime, 1) => {
                             if date_val.month() - 1 == 0 {
-                                date_val.with_year(date_val.year() - 1).unwrap().with_month(12).unwrap()
+                                date_val
+                                    .with_year(date_val.year() - 1)
+                                    .unwrap()
+                                    .with_month(12)
+                                    .unwrap()
                             } else {
                                 date_val.with_month(date_val.month() - 1).unwrap()
                             }
                         }
-                        (DateType::DateTime, 2) => date_val.checked_sub_signed(Duration::days(1)).unwrap(),
-                        (DateType::DateTime, 3) => date_val.checked_sub_signed(Duration::hours(1)).unwrap(),
-                        (DateType::DateTime, 4) => date_val.checked_sub_signed(Duration::minutes(1)).unwrap(),
-                        (DateType::DateTime, 5) => date_val.checked_sub_signed(Duration::seconds(1)).unwrap(),
+                        (DateType::DateTime, 2) => {
+                            date_val.checked_sub_signed(Duration::days(1)).unwrap()
+                        }
+                        (DateType::DateTime, 3) => {
+                            date_val.checked_sub_signed(Duration::hours(1)).unwrap()
+                        }
+                        (DateType::DateTime, 4) => {
+                            date_val.checked_sub_signed(Duration::minutes(1)).unwrap()
+                        }
+                        (DateType::DateTime, 5) => {
+                            date_val.checked_sub_signed(Duration::seconds(1)).unwrap()
+                        }
                         (DateType::Date, _) => panic!("stepped out of bounds on Date"),
                         (DateType::Time, _) => panic!("stepped out of bounds on Time"),
                         (DateType::DateTime, _) => panic!("stepped out of bounds on DateTime"),
                     };
                     digits = Vec::with_capacity(4);
-                },
+                }
                 // Allow numerical inputs.
                 Key::Char(val) => {
                     if val.is_digit(10) {
                         digits.push(val.to_digit(10).unwrap());
                         // Need 4 digits to set year
                         if pos == 0 && digits.len() == 4 {
-                            let num = digits[0] * 1000 + digits[1] * 100 + digits[2] * 10 + digits[3];
+                            let num =
+                                digits[0] * 1000 + digits[1] * 100 + digits[2] * 10 + digits[3];
                             date_val = match &self.date_type {
                                 DateType::Date => date_val.with_year(num as i32).unwrap(),
                                 DateType::DateTime => date_val.with_year(num as i32).unwrap(),
@@ -331,22 +392,39 @@ impl <'a> DateTimeSelect<'a> {
                             };
                             digits = Vec::with_capacity(4);
                         // Have 2 digits in any position, including 0 if hours.
-                        } else if digits.len() == 2 && (pos > 0  || self.date_type == DateType::Time) {
+                        } else if digits.len() == 2 && (pos > 0 || self.date_type == DateType::Time)
+                        {
                             let num = digits[0] * 10 + digits[1];
                             date_val = match (&self.date_type, pos) {
                                 (DateType::Date, 1) => date_val.with_month(num).unwrap_or(date_val),
                                 (DateType::Date, 2) => date_val.with_day(num).unwrap_or(date_val),
                                 (DateType::Time, 0) => date_val.with_hour(num).unwrap_or(date_val),
-                                (DateType::Time, 1) => date_val.with_minute(num).unwrap_or(date_val),
-                                (DateType::Time, 2) => date_val.with_second(num).unwrap_or(date_val),
-                                (DateType::DateTime, 1) => date_val.with_month(num).unwrap_or(date_val),
-                                (DateType::DateTime, 2) => date_val.with_day(num).unwrap_or(date_val),
-                                (DateType::DateTime, 3) => date_val.with_hour(num).unwrap_or(date_val),
-                                (DateType::DateTime, 4) => date_val.with_minute(num).unwrap_or(date_val),
-                                (DateType::DateTime, 5) => date_val.with_second(num).unwrap_or(date_val),
+                                (DateType::Time, 1) => {
+                                    date_val.with_minute(num).unwrap_or(date_val)
+                                }
+                                (DateType::Time, 2) => {
+                                    date_val.with_second(num).unwrap_or(date_val)
+                                }
+                                (DateType::DateTime, 1) => {
+                                    date_val.with_month(num).unwrap_or(date_val)
+                                }
+                                (DateType::DateTime, 2) => {
+                                    date_val.with_day(num).unwrap_or(date_val)
+                                }
+                                (DateType::DateTime, 3) => {
+                                    date_val.with_hour(num).unwrap_or(date_val)
+                                }
+                                (DateType::DateTime, 4) => {
+                                    date_val.with_minute(num).unwrap_or(date_val)
+                                }
+                                (DateType::DateTime, 5) => {
+                                    date_val.with_second(num).unwrap_or(date_val)
+                                }
                                 (DateType::Date, _) => panic!("stepped out of bounds on Date"),
                                 (DateType::Time, _) => panic!("stepped out of bounds on Time"),
-                                (DateType::DateTime, _) => panic!("stepped out of bounds on DateTime"),
+                                (DateType::DateTime, _) => {
+                                    panic!("stepped out of bounds on DateTime")
+                                }
                             };
                             digits = Vec::with_capacity(4);
                         }
@@ -356,7 +434,7 @@ impl <'a> DateTimeSelect<'a> {
                 }
                 _ => {}
             }
-            date_val = self.check_date(date_val, &min_val, &max_val);
+            date_val = self.check_date(date_val);
             render.clear()?;
             if self.show_match {
                 term.clear_last_lines(1)?;
@@ -380,7 +458,14 @@ mod tests {
     fn test_setting_proper_rfc3339_default() {
         let mut datetime_select = DateTimeSelect::new();
         datetime_select.default("2019-01-01T00:00:00-00:00");
-        assert_eq!(datetime_select.default, Some("2019-01-01T00:00:00-00:00".to_owned()));
+        assert_eq!(
+            datetime_select.default,
+            Some(
+                FixedOffset::east(0)
+                    .ymd(2019, 1, 1)
+                    .and_hms_milli(0, 0, 0, 0)
+            )
+        );
     }
     #[test]
     fn test_setting_prompt() {

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -459,6 +459,9 @@ impl<'a> DateTimeSelect<'a> {
                         digits.clear();
                     }
                 }
+                Key::Backspace => {
+                    digits.pop();
+                }
                 _ => {}
             }
             date_val = self.check_date(date_val);


### PR DESCRIPTION
This PR fixes the following issues:
- changing the year when on leap day no longer panics
- changing the month when the day is invalid in the new month no longer panics (e.g. decrement month on 2020-03-30)
- no backspace support when manually entering a component
- datetime result is not formatted in correct RFC3339 format
- max and min can be set without a valid range

The code is also refactored and simplified.